### PR TITLE
make the dict file working

### DIFF
--- a/dict/en.ini
+++ b/dict/en.ini
@@ -1,5 +1,5 @@
 ; English (United States)
-dict.wiki.wiki=Wiki
-dict.wiki.page_title=Page Title
-dict.wiki.slug=Slug
-dict.wiki.content=Content
+wiki.wiki=Wiki
+wiki.page_title=Page Title
+wiki.slug=Slug
+wiki.content=Content


### PR DESCRIPTION
the dict. prefix is added by the framework. It's superfluous here and would add the lang key at `dict.dict.wiki.wiki` instead.