### PR TITLE
Updated href of "Create a Page" on empty wiki.

### DIFF
--- a/view/wiki/index.html
+++ b/view/wiki/index.html
@@ -30,7 +30,7 @@
 					<p class="h3"><span class="glyphicon glyphicon-book"></span></p>
 					<h3>Welcome to the wiki!</h3>
 					<p>Wikis let you collaboratively build documentation for your projects.</p>
-					<a href="#" class="btn btn-primary btn-sm">Create a Page</a>
+					<a href="{{ @BASE }}/wiki/edit/" class="btn btn-primary btn-sm">Create a Page</a>
 				</div>
 			</div>
 		</false>


### PR DESCRIPTION
If wiki is empty, e.g. when the plugin is newly installed, it shows "Welcome to the wiki!" and "Create a Page". This button previously did nothing.
Updated the href to wiki/edit/ thus the user create a new page.